### PR TITLE
allow adding more to the definition of carpets and automatically use the data of the recipe node

### DIFF
--- a/carpet_api/init.lua
+++ b/carpet_api/init.lua
@@ -1,18 +1,91 @@
-function register_carpet(name, recipe, desc, texture, group)
-	minetest.register_node(":carpet:"..name, {
-		description = desc,
-		tiles = {texture},
-		paramtype = "light",
-		drawtype = "nodebox",
-		groups = group,
-		node_box = {
-			type = "fixed",
-			fixed = {-0.5, -0.5, -0.5, 0.5, -0.5+0.0625, 0.5}
-		},
+minetest.on_place = minetest.on_place or function(name, func)
+	local previous_on_place = minetest.registered_nodes[name].on_place
+	minetest.override_item(name, {
+		on_place = function(itemstack, placer, pointed_thing)
+			if func(itemstack, placer, pointed_thing) then
+				return previous_on_place(itemstack, placer, pointed_thing)
+			end
+		end
 	})
+end
+
+local carpet_def = {
+	paramtype = "light",
+	drawtype = "nodebox",
+	node_box = {
+		type = "fixed",
+		fixed = {-0.5, -0.5, -0.5, 0.5, -0.5+0.0625, 0.5}
+	},
+}
+function register_carpet(name, recipe, desc, texture, group)
+	local data
+	if desc then
+		-- support the previous carpet registration function
+		data = {
+			recipe = recipe,
+			description = desc,
+			texture = texture,
+			groups = group,
+			drop = "disable",
+		}
+	else
+		data = recipe
+	end
+	recipe = data.recipe
+	data.recipe = nil
+	local recipedata = table.copy(minetest.registered_nodes[recipe])
+
+	-- fill specific carped def
+	for n,i in pairs(data) do
+		-- allows disabling drop, on_punch, ect.
+		if i == "disable" then
+			recipedata[n] = nil
+		else
+			recipedata[n] = i
+		end
+	end
+
+	-- fill fixed carped def
+	for n,i in pairs(carpet_def) do
+		recipedata[n] = i
+	end
+
+	local desc = recipedata.description
+	if not string.find(string.lower(desc), "carpet") then
+		recipedata.description = recipedata.description.." Carpet"
+	end
+
+	recipedata.tiles = recipedata.texture and {recipedata.texture} or recipedata.tiles or recipedata.tile_images
+	recipedata.texture = nil
+	recipedata.tile_images = nil
+
+	recipedata.groups = recipedata.groups or {oddly_breakable_by_hand=3}
+	recipedata.groups.falling_node = 1
+
+	if not name then
+		name = string.split(recipe, ":")
+		name = name[1].."_"..name[2]
+	end
+	name = "carpet:"..name
+
+	minetest.register_node(":"..name, recipedata)
+
+	-- disallow carpets to be placed onto other ones
+	minetest.on_place(name, function(_, _, pointed_thing)
+		if not pointed_thing then
+			return
+		end
+		local pos = pointed_thing.under
+		local above = pointed_thing.above
+		if above.y == pos.y+1
+		and minetest.get_node(pos).name == name then
+			return
+		end
+		return true
+	end)
 	
 	minetest.register_craft({
-		output = 'carpet:'..name..' 32',
+		output = name.." 32",
 		recipe = {
 			{recipe, recipe},
 		}

--- a/carpet_api/init.lua
+++ b/carpet_api/init.lua
@@ -31,6 +31,13 @@ function register_carpet(name, recipe, desc, texture, group)
 	else
 		data = recipe
 	end
+
+	-- fix for automatically made names
+	if not data then
+		data = name
+		name = nil
+	end
+
 	recipe = data.recipe
 	data.recipe = nil
 	local recipedata = table.copy(minetest.registered_nodes[recipe])

--- a/carpet_api/init.lua
+++ b/carpet_api/init.lua
@@ -67,7 +67,10 @@ function register_carpet(name, recipe, desc, texture, group)
 	recipedata.tile_images = nil
 
 	recipedata.groups = recipedata.groups or {oddly_breakable_by_hand=3}
-	recipedata.groups.falling_node = 1
+	if recipedata.falling_carpet ~= false then
+		recipedata.groups.falling_node = 1
+	end
+	recipedata.falling_carpet = nil
 
 	if not name then
 		name = string.split(recipe, ":")
@@ -75,21 +78,26 @@ function register_carpet(name, recipe, desc, texture, group)
 	end
 	name = "carpet:"..name
 
+	local limit_placing = recipedata.nofly_carpet
+	recipedata.nofly_carpet = nil
+
 	minetest.register_node(":"..name, recipedata)
 
-	-- disallow carpets to be placed onto other ones
-	minetest.on_place(name, function(_, _, pointed_thing)
-		if not pointed_thing then
-			return
-		end
-		local pos = pointed_thing.under
-		local above = pointed_thing.above
-		if above.y == pos.y+1
-		and minetest.get_node(pos).name == name then
-			return
-		end
-		return true
-	end)
+	if limit_placing ~= false then
+		-- disallow carpets to be placed onto other ones
+		minetest.on_place(name, function(_, _, pointed_thing)
+			if not pointed_thing then
+				return
+			end
+			local pos = pointed_thing.under
+			local above = pointed_thing.above
+			if above.y == pos.y+1
+			and minetest.get_node(pos).name == name then
+				return
+			end
+			return true
+		end)
+	end
 	
 	minetest.register_craft({
 		output = name.." 32",

--- a/carpet_plus/init.lua
+++ b/carpet_plus/init.lua
@@ -1,5 +1,5 @@
 if minetest.get_modpath("default") then
-	register_carpet("default_stone", "default:stone", "Stone Carpet", "default_stone.png", {cracky=3, stone=1})
+	register_carpet({recipe = "default:stone", drop = "disable"})
 	register_carpet("default_cobble", "default:cobble", "Cobblestone Carpet", "default_cobble.png", {cracky=3, stone=2})
 	register_carpet("default_stonebrick", "default:stonebrick", "Stone Brick Carpet", "default_stone_brick.png", {cracky=2, stone=1})
 	register_carpet("default_mossycobble", "default:mossycobble", "Mossy Cobblestone Carpet", "default_mossycobble.png", {cracky=3, stone=1})


### PR DESCRIPTION
and add carpets to the falling_node group and disallow placing a carpet onto another one that it doesn't look like carpets can fly